### PR TITLE
fixed popup position when godot window is not maximizied

### DIFF
--- a/addons/imjp94.yafsm/scenes/StateMachineEditor.gd
+++ b/addons/imjp94.yafsm/scenes/StateMachineEditor.gd
@@ -294,7 +294,7 @@ func _gui_input(event):
 				if event.pressed and can_gui_context_menu:
 					context_menu.set_item_disabled(1, current_layer.state_machine.has_entry())
 					context_menu.set_item_disabled(2, current_layer.state_machine.has_exit())
-					context_menu.position = get_viewport().get_mouse_position()
+					context_menu.position = event.position + get_screen_position()
 					context_menu.popup()
 
 func _input(event):
@@ -375,7 +375,7 @@ func _on_state_node_gui_input(event, node):
 				if event.pressed:
 					# State node context menu
 					_context_node = node
-					state_node_context_menu.position = get_viewport().get_mouse_position()
+					state_node_context_menu.position = event.position + node.get_screen_position()
 					state_node_context_menu.popup()
 					state_node_context_menu.set_item_disabled(3, not (node.state is StateMachine))
 					accept_event()

--- a/addons/imjp94.yafsm/scripts/Utils.gd
+++ b/addons/imjp94.yafsm/scripts/Utils.gd
@@ -16,6 +16,7 @@ static func popup_on_target(popup, target):
 
 		if usable_rect.encloses(cp_rect):
 			break
+	cp_rect.position += DisplayServer.window_get_position() as Vector2
 	popup.set_position(cp_rect.position)
 	popup.popup()
 

--- a/addons/imjp94.yafsm/scripts/Utils.gd
+++ b/addons/imjp94.yafsm/scripts/Utils.gd
@@ -1,7 +1,7 @@
 # Position Popup near to its target while within window, solution from ColorPickerButton source code(https://github.com/godotengine/godot/blob/6d8c14f849376905e1577f9fc3f9512bcffb1e3c/scene/gui/color_picker.cpp#L878)
 static func popup_on_target(popup, target):
 	popup.reset_size()
-	var usable_rect = Rect2(Vector2.ZERO, DisplayServer.window_get_real_size())
+	var usable_rect = Rect2(Vector2.ZERO, DisplayServer.window_get_size_with_decorations())
 	var cp_rect = Rect2(Vector2.ZERO, popup.get_size())
 	for i in 4:
 		if i > 1:


### PR DESCRIPTION
This should make the popup always pop up on the desired position. Previously, if your editor window was offset by (x,y) pixels, the popups would spawn at an offset of (-x,-y) of your mouse position.